### PR TITLE
build against bundled PCRE and fix some macors

### DIFF
--- a/SPECS/php56u.spec
+++ b/SPECS/php56u.spec
@@ -468,8 +468,8 @@ Provides: %{name}-mysqli = %{version}-%{release}
 Provides: %{real_name}-mysqli = %{version}-%{release}
 Provides: %{name}-mysqli%{?_isa} = %{version}-%{release}
 Provides: %{real_name}-mysqli%{?_isa} = %{version}-%{release}
-Provides: %{name}-pdo_mysql, php-pdo_mysql%{?_isa}
-Provides: %{real_name}-pdo_mysql, php-pdo_mysql%{?_isa}
+Provides: %{name}-pdo_mysql, %{name}-pdo_mysql%{?_isa}
+Provides: %{real_name}-pdo_mysql, %{real_name}-pdo_mysql%{?_isa}
 
 %description mysqlnd
 The php-mysqlnd package contains a dynamic shared object that will add


### PR DESCRIPTION
Building against the bundled PCRE instead of the system PCRE has been done in these previous bug reports:

php53u - https://bugs.launchpad.net/ius/+bug/608119
php54 - https://bugs.launchpad.net/ius/+bug/1039187
php55u - https://bugs.launchpad.net/ius/+bug/1215089
