### PR TITLE
Remove default opcache extension ini creation

### DIFF
--- a/SPECS/php56u.spec
+++ b/SPECS/php56u.spec
@@ -1505,7 +1505,7 @@ for mod in pgsql odbc ldap snmp xmlrpc imap \
     mysqlnd mysql mysqli pdo_mysql \
     mbstring gd dom xsl soap bcmath dba xmlreader xmlwriter \
     simplexml bz2 calendar ctype exif ftp gettext gmp iconv \
-    sockets tokenizer opcache \
+    sockets tokenizer \
     pdo pdo_pgsql pdo_odbc pdo_sqlite \
 %if %{with_zip}
     zip \


### PR DESCRIPTION
Opcache isn't a standard PHP extension, instead a Zend extension, needing zend_extension= syntax instead.

Additionally, this is happening already under 10-opcache.ini, but attempting to then load the extension as
a standard extension might introduce strange behaviour.